### PR TITLE
Update Spanish copy to friendly tone

### DIFF
--- a/app/contacto/page.tsx
+++ b/app/contacto/page.tsx
@@ -18,7 +18,7 @@ export default function ContactPage() {
     e.preventDefault();
     // Handle form submission here
     console.log('Form submitted:', formData);
-    alert('Gracias por vuestro interés. Nos pondremos en contacto pronto.');
+    alert('Gracias por tu interés. Nos pondremos en contacto pronto.');
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -35,10 +35,10 @@ export default function ContactPage() {
         <div className="ninja-container">
           <div className="text-center mb-16">
             <h1 className="ninja-heading-xl mb-6">
-              Hablemos de vuestras integraciones
+              Hablemos de tus integraciones
             </h1>
             <p className="ninja-body-lg max-w-3xl mx-auto">
-              Contactad con nuestro equipo para una demo personalizada o resolver cualquier duda.
+              Contacta con nuestro equipo para una demo personalizada o resolver cualquier duda.
             </p>
           </div>
         </div>
@@ -50,7 +50,7 @@ export default function ContactPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
             {/* Contact Form */}
             <div>
-              <h2 className="ninja-heading-lg mb-8">Solicitad una demo</h2>
+              <h2 className="ninja-heading-lg mb-8">Solicita una demo</h2>
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
@@ -65,7 +65,7 @@ export default function ContactPage() {
                       value={formData.name}
                       onChange={handleChange}
                       className="ninja-input"
-                      placeholder="Vuestro nombre"
+                      placeholder="Nombre"
                     />
                   </div>
                   <div>
@@ -80,7 +80,7 @@ export default function ContactPage() {
                       value={formData.email}
                       onChange={handleChange}
                       className="ninja-input"
-                      placeholder="vuestro@email.com"
+                      placeholder="tu@email.com"
                     />
                   </div>
                 </div>
@@ -128,7 +128,7 @@ export default function ContactPage() {
                     value={formData.message}
                     onChange={handleChange}
                     className="ninja-textarea"
-                    placeholder="Contadnos sobre vuestras necesidades de integración..."
+                    placeholder="Cuéntanos sobre tus necesidades de integración..."
                   />
                 </div>
 
@@ -192,9 +192,9 @@ export default function ContactPage() {
               {/* Calendar Integration */}
               <div className="mt-8">
                 <div className="ninja-card ninja-hover-lift text-center">
-                  <h3 className="ninja-heading-md mb-4">Reservad una reunión</h3>
+                  <h3 className="ninja-heading-md mb-4">Reserva una reunión</h3>
                   <p className="text-[#a0c4d4] mb-6">
-                    ¿Preferís hablar directamente? Reservad una slot en nuestro calendario.
+                    ¿Prefieres hablar directamente? Reserva un hueco en nuestro calendario.
                   </p>
                   <Button className="ninja-button-secondary">
                     Abrir calendario

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Connect Ninjas - Conectores API automáticos on-prem',
-  description: 'Integraciones API 100% automáticas y on-prem. Descargad vuestro conector en minutos. Sin vendor lock-in.',
+  description: 'Integraciones API 100% automáticas y on-prem. Descarga tu conector en minutos. Sin vendor lock-in.',
   keywords: 'integraciones API on-prem, conector C#, NDC integration, conectores automáticos',
   authors: [{ name: 'Connect Ninjas' }],
   creator: 'Connect Ninjas',
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     url: 'https://connectninjas.com',
     siteName: 'Connect Ninjas',
     title: 'Connect Ninjas - Conectores API automáticos on-prem',
-    description: 'Integraciones API 100% automáticas y on-prem. Descargad vuestro conector en minutos. Sin vendor lock-in.',
+    description: 'Integraciones API 100% automáticas y on-prem. Descarga tu conector en minutos. Sin vendor lock-in.',
     images: [
       {
         url: '/og-image.png',
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
     site: '@connectninjas',
     creator: '@connectninjas',
     title: 'Connect Ninjas - Conectores API automáticos on-prem',
-    description: 'Integraciones API 100% automáticas y on-prem. Descargad vuestro conector en minutos. Sin vendor lock-in.',
+    description: 'Integraciones API 100% automáticas y on-prem. Descarga tu conector en minutos. Sin vendor lock-in.',
     images: ['/og-image.png'],
   },
   robots: {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
             <h1 className="text-9xl font-bold text-[#b8ff60] mb-4">404</h1>
             <h2 className="ninja-heading-lg mb-6">Página no encontrada</h2>
             <p className="ninja-body-lg max-w-2xl mx-auto">
-              Lo sentimos, la página que buscáis no existe o ha sido movida.
+              Lo sentimos, la página que buscas no existe o ha sido movida.
             </p>
           </div>
           

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,10 @@ import PricingCards from '@/components/PricingCards';
 
 export const metadata: Metadata = {
   title: 'Connect Ninjas - Conectores API automáticos on-prem',
-  description: 'Descargad vuestro conector API en minutos. Integraciones 100% automáticas y on-prem. Sin vendor lock-in.',
+  description: 'Descarga tu conector API en minutos. Integraciones 100% automáticas y on-prem. Sin vendor lock-in.',
   openGraph: {
     title: 'Connect Ninjas - Conectores API automáticos on-prem',
-    description: 'Descargad vuestro conector API en minutos. Integraciones 100% automáticas y on-prem. Sin vendor lock-in.',
+    description: 'Descarga tu conector API en minutos. Integraciones 100% automáticas y on-prem. Sin vendor lock-in.',
   },
 };
 

--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -14,15 +14,15 @@ const faqs = [
   },
   {
     question: '¿Qué pasa si el proveedor cambia su API?',
-    answer: 'Con el mantenimiento anual, actualizamos automáticamente vuestro conector cuando el proveedor modifica su API. Recibís notificaciones y el nuevo conector sin coste adicional.',
+    answer: 'Con el mantenimiento anual, actualizamos automáticamente tu conector cuando el proveedor modifica su API. Recibes notificaciones y el nuevo conector sin coste adicional.',
   },
   {
     question: '¿Puedo modificar el código del conector?',
-    answer: 'Sí, recibís el código fuente completo. Podéis modificarlo, extenderlo o mantenerlo internamente. No hay vendor lock-in.',
+    answer: 'Sí, recibes el código fuente completo. Puedes modificarlo, extenderlo o mantenerlo internamente. No hay vendor lock-in.',
   },
   {
     question: '¿Qué significa "1 cambio de dominio del cliente"?',
-    answer: 'Si necesitáis modificar vuestro modelo de datos o lógica de negocio, incluimos 1 cambio gratuito al año. Cambios adicionales se facturan por separado.',
+    answer: 'Si necesitas modificar tu modelo de datos o lógica de negocio, incluimos 1 cambio gratuito al año. Cambios adicionales se facturan por separado.',
   },
   {
     question: '¿Qué son los "requisitos ad-hoc"?',
@@ -30,7 +30,7 @@ const faqs = [
   },
   {
     question: '¿Ofrecéis descuentos por volumen?',
-    answer: 'Sí, para múltiples conectores o contratos plurianuales ofrecemos descuentos. Contactad con nuestro equipo comercial para más información.',
+    answer: 'Sí, para múltiples conectores o contratos plurianuales ofrecemos descuentos. Contacta con nuestro equipo comercial para más información.',
   },
 ];
 
@@ -88,7 +88,7 @@ export default function PricingPage() {
               </div>
               <h3 className="ninja-heading-md mb-4">Sin vendor lock-in</h3>
               <p className="text-[#a0c4d4]">
-                Recibís el código fuente completo. Podéis modificarlo y mantenerlo internamente sin depender de nosotros.
+                Recibes el código fuente completo. Puedes modificarlo y mantenerlo internamente sin depender de nosotros.
               </p>
             </div>
 
@@ -98,7 +98,7 @@ export default function PricingPage() {
               </div>
               <h3 className="ninja-heading-md mb-4">ROI inmediato</h3>
               <p className="text-[#a0c4d4]">
-                Ahorrais meses de desarrollo y miles de euros en costes de personal. El ROI se ve desde el primer día.
+                Ahorras meses de desarrollo y miles de euros en costes de personal. El ROI se ve desde el primer día.
               </p>
             </div>
 

--- a/app/producto/page.tsx
+++ b/app/producto/page.tsx
@@ -12,17 +12,17 @@ const features = [
   {
     icon: Zap,
     title: 'Generación automática',
-    description: 'Nuestra IA analiza vuestra documentación y genera el conector completo sin intervención manual.',
+    description: 'Nuestra IA analiza tu documentación y genera el conector completo sin intervención manual.',
   },
   {
     icon: Shield,
     title: 'Despliegue on-prem',
-    description: 'Vuestros datos nunca salen de vuestra infraestructura. Control total y seguridad garantizada.',
+    description: 'Tus datos nunca salen de tu infraestructura. Control total y seguridad garantizada.',
   },
   {
     icon: RefreshCw,
     title: 'Actualizaciones automáticas',
-    description: 'Cuando el proveedor actualiza su API, regeneramos vuestro conector automáticamente.',
+    description: 'Cuando el proveedor actualiza su API, regeneramos tu conector automáticamente.',
   },
   {
     icon: Code,
@@ -32,7 +32,7 @@ const features = [
   {
     icon: Download,
     title: 'Sin vendor lock-in',
-    description: 'Recibís el código fuente completo. Podéis modificarlo y mantenerlo internamente.',
+    description: 'Recibes el código fuente completo. Puedes modificarlo y mantenerlo internamente.',
   },
   {
     icon: Clock,
@@ -74,7 +74,7 @@ export default function ProductPage() {
               Características principales
             </h2>
             <p className="ninja-body-lg max-w-3xl mx-auto">
-              Todo lo que necesitáis para integraciones API exitosas.
+              Todo lo que necesitas para integraciones API exitosas.
             </p>
           </div>
 
@@ -141,10 +141,10 @@ export default function ProductPage() {
         <div className="ninja-container">
           <div className="text-center">
             <h2 className="ninja-heading-lg mb-6">
-              ¿Listos para empezar?
+              ¿Listo para empezar?
             </h2>
             <p className="ninja-body-lg mb-8 max-w-2xl mx-auto">
-              Solicitad una demo personalizada y ved cómo podemos acelerar vuestras integraciones.
+              Solicita una demo personalizada y ve cómo podemos acelerar tus integraciones.
             </p>
             <Link href="/contacto">
               <Button className="ninja-button ninja-hover-lift">

--- a/app/recursos/page.tsx
+++ b/app/recursos/page.tsx
@@ -19,7 +19,7 @@ const blogPosts = [
   },
   {
     title: 'Automatización de conectores C# con IA',
-    excerpt: 'Descubrid cómo nuestra IA analiza documentación API y genera código C# optimizado para integraciones.',
+    excerpt: 'Descubre cómo nuestra IA analiza documentación API y genera código C# optimizado para integraciones.',
     date: '10 Mar 2024',
     author: 'María González',
     category: 'Técnico',
@@ -37,7 +37,7 @@ const blogPosts = [
   },
   {
     title: 'Seguridad en integraciones API: Guía 2024',
-    excerpt: 'Todo lo que necesitáis saber sobre seguridad en integraciones API, con foco en despliegues on-prem.',
+    excerpt: 'Todo lo que necesitas saber sobre seguridad en integraciones API, con foco en despliegues on-prem.',
     date: '28 Feb 2024',
     author: 'Alex Rodríguez',
     category: 'Seguridad',

--- a/app/sobre-nosotros/page.tsx
+++ b/app/sobre-nosotros/page.tsx
@@ -15,7 +15,7 @@ const values = [
   {
     icon: Shield,
     title: 'Seguridad',
-    description: 'Vuestros datos nunca salen de vuestra infraestructura. Seguridad by design.',
+    description: 'Tus datos nunca salen de tu infraestructura. Seguridad by design.',
   },
   {
     icon: Users,

--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -79,7 +79,7 @@ export default function ComparisonTable() {
             ¿Por qué Connect Ninjas?
           </h2>
           <p className="ninja-body-lg max-w-3xl mx-auto">
-            Comparad nuestra solución automatizada con el desarrollo manual tradicional.
+            Compara nuestra solución automatizada con el desarrollo manual tradicional.
           </p>
         </div>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
               <span className="text-xl font-bold text-[#e8f6ff]">Connect Ninjas</span>
             </Link>
             <p className="text-[#a0c4d4] mb-6 max-w-md">
-              Integraciones API 100% automáticas y on-prem. Descargad vuestro conector en minutos. Sin vendor lock-in.
+              Integraciones API 100% automáticas y on-prem. Descarga tu conector en minutos. Sin vendor lock-in.
             </p>
             <div className="space-y-2">
               <div className="flex items-center space-x-2 text-[#a0c4d4]">

--- a/components/PricingCards.tsx
+++ b/components/PricingCards.tsx
@@ -10,7 +10,7 @@ const pricingPlans = [
     price: '20.000',
     currency: '€',
     period: 'pago único',
-    description: 'Perfecto para comenzar con vuestra primera integración API',
+    description: 'Perfecto para comenzar con tu primera integración API',
     features: [
       'Conector API personalizado',
       'Documentación completa',
@@ -27,7 +27,7 @@ const pricingPlans = [
     price: '2.000',
     currency: '€',
     period: 'por año',
-    description: 'Mantened vuestro conector actualizado automáticamente',
+    description: 'Mantén tu conector actualizado automáticamente',
     features: [
       'Actualizaciones ilimitadas del proveedor',
       '1 cambio de dominio del cliente',
@@ -116,10 +116,10 @@ export default function PricingCards() {
               <Shield className="h-8 w-8 text-[#b8ff60]" />
             </div>
             <h3 className="ninja-heading-md mb-4">Garantía de satisfacción</h3>
-            <p className="text-[#a0c4d4]">
-              Si no estáis satisfechos con el conector en los primeros 30 días, 
-              os devolvemos el 100% del importe. Sin preguntas.
-            </p>
+              <p className="text-[#a0c4d4]">
+                Si no estás satisfecho con el conector en los primeros 30 días,
+                te devolvemos el 100% del importe. Sin preguntas.
+              </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- reword Spanish copy to use `tú` instead of `vosotros`
- refresh various descriptions, placeholders and headings

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68757848ce6c832caa28c2430d3cc8d3