### PR TITLE
Move Java card before Python

### DIFF
--- a/app/producto/page.tsx
+++ b/app/producto/page.tsx
@@ -49,8 +49,8 @@ const features = [
 
 const languages = [
   { name: 'C#', status: 'available', description: 'Completamente soportado' },
-  { name: 'Python', status: 'coming', description: 'Q2 2024' },
   { name: 'Java', status: 'available', description: 'Completamente soportado' },
+  { name: 'Python', status: 'coming', description: 'Q2 2024' },
   { name: 'Node.js', status: 'coming', description: 'Q4 2024' },
 ];
 


### PR DESCRIPTION
## Summary
- reorder Java in Supported Languages list so it appears second

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_b_6876ce3f7488832c867d4487e78ea79d